### PR TITLE
0.6.0, fix the unescape bug

### DIFF
--- a/lib/ronin/formatting/extensions/text/string.rb
+++ b/lib/ronin/formatting/extensions/text/string.rb
@@ -283,7 +283,7 @@ class String
       end
     end
 
-    return buffer.force_encoding(Encoding::UTF_8)
+    return buffer.force_encoding(__ENCODING__)
   end
 
 end


### PR DESCRIPTION
bug like this

```
>> buff = ''
>> buf << 0xe2
>> buf.bytes
=> [195, 162]
```

buf auto convert 0xe2 to 2 bytes since it's an utf-8
I also reverse it back to the default encoding after finishing.
