### PR TITLE
Auto include Ronin::Support

### DIFF
--- a/lib/ronin/support.rb
+++ b/lib/ronin/support.rb
@@ -27,3 +27,5 @@ require 'ronin/path'
 require 'ronin/templates'
 require 'ronin/support/support'
 require 'ronin/support/version'
+
+include Ronin::Support


### PR DESCRIPTION
To `require 'ronin/support'` as a standalone
