### PR TITLE
feat: connect methods' block behavior

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,8 @@
-### next
+### 1.0.6 / 2023-XX-XX
 
 * {Ronin::Support::Network::TCP.connect}, {Ronin::Support::Network::UDP.connect}, and
-  {Ronin::Support::Network::HTTP.connect}, when passed a block, return the block's return value.
-* {Ronin::Support::Network::TCP.connect} and {Ronin::Support::Network::UDP.connect} properly close the
+  {Ronin::Support::Network::HTTP.connect}, when given a block, now returns the block's return value.
+* {Ronin::Support::Network::TCP.connect} and {Ronin::Support::Network::UDP.connect} properly closes the
   socket when passed a block that raises an exception.
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+### next
+
+* {Ronin::Support::Network::TCP.connect}, {Ronin::Support::Network::UDP.connect}, and
+  {Ronin::Support::Network::HTTP.connect}, when passed a block, return the block's return value.
+* {Ronin::Support::Network::TCP.connect} and {Ronin::Support::Network::UDP.connect} properly close the
+  socket when passed a block that raises an exception.
+
+
 ### 1.0.5 / 2023-12-27
 
 * Fixed a bug in {Ronin::Support::Binary::Stream::Methods#read_string} on Ruby
@@ -704,4 +712,3 @@
   * Require combinatorics ~> 0.3.
   * Require uri-query_params ~> 0.5, >= 0.5.2.
   * Require data_paths ~> 0.2, >= 0.2.1.
-

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-### 1.0.6 / 2023-XX-XX
+### 1.0.6 / 2024-XX-XX
 
 * {Ronin::Support::Network::TCP.connect}, {Ronin::Support::Network::UDP.connect}, and
   {Ronin::Support::Network::HTTP.connect}, when given a block, now returns the block's return value.

--- a/lib/ronin/support/network/http.rb
+++ b/lib/ronin/support/network/http.rb
@@ -473,8 +473,11 @@ module Ronin
           http = new(host,port, ssl: ssl, **kwargs)
 
           if block_given?
-            yield http
-            http.close
+            begin
+              yield http
+            ensure
+              http.close
+            end
           else
             return http
           end

--- a/lib/ronin/support/network/pop3/mixin.rb
+++ b/lib/ronin/support/network/pop3/mixin.rb
@@ -100,8 +100,11 @@ module Ronin
             pop3.start(user,password)
 
             if block_given?
-              yield pop3
-              pop3.finish
+              begin
+                yield pop3
+              ensure
+                pop3.finish
+              end
             else
               return pop3
             end

--- a/lib/ronin/support/network/smtp/mixin.rb
+++ b/lib/ronin/support/network/smtp/mixin.rb
@@ -164,8 +164,11 @@ module Ronin
             smtp.start(helo,user,password,auth)
 
             if block_given?
-              yield smtp
-              smtp.finish
+              begin
+                yield smtp
+              ensure
+                smtp.finish
+              end
             else
               return smtp
             end

--- a/lib/ronin/support/network/tcp.rb
+++ b/lib/ronin/support/network/tcp.rb
@@ -131,8 +131,11 @@ module Ronin
                    end
 
           if block_given?
-            yield socket
-            socket.close
+            begin
+              yield socket
+            ensure
+              socket.close
+            end
           else
             return socket
           end

--- a/lib/ronin/support/network/udp.rb
+++ b/lib/ronin/support/network/udp.rb
@@ -137,8 +137,11 @@ module Ronin
           socket.connect(host,port)
 
           if block_given?
-            yield socket
-            socket.close
+            begin
+              yield socket
+            ensure
+              socket.close
+            end
           else
             return socket
           end

--- a/spec/network/http_spec.rb
+++ b/spec/network/http_spec.rb
@@ -442,6 +442,14 @@ describe Ronin::Support::Network::HTTP do
           described_class.connect(host,port,&b)
         }.to yield_with_args(described_class)
       end
+
+      it "must return the block's return value" do
+        returned_value = described_class.connect(host,port) do
+          :return_value
+        end
+
+        expect(returned_value).to eq(:return_value)
+      end
     end
   end
 

--- a/spec/network/pop3/mixin_spec.rb
+++ b/spec/network/pop3/mixin_spec.rb
@@ -58,6 +58,16 @@ describe Ronin::Support::Network::POP3::Mixin do
           expect(yielded_pop3).to be_kind_of(Net::POP3)
         end
 
+        it "must return the block's return value" do
+          pending "need valid POP3 credentials"
+
+          returned_value = subject.pop3_connect(host, port: port, ssl: true) do |pop3|
+            :return_value
+          end
+
+          expect(returned_value).to be(:return_value)
+        end
+
         it "must finish the POP3 session after yielding it" do
           pending "need valid POP3 credentials"
 
@@ -71,6 +81,26 @@ describe Ronin::Support::Network::POP3::Mixin do
 
           expect(was_started).to be(true)
           expect(pop3).to_not be_started
+        end
+
+        context "when the block raises an exception" do
+          it "must finish the POP3 session after yielding it" do
+            pending "need valid POP3 credentials"
+
+            pop3        = nil
+            was_started = nil
+
+            expect do
+              subject.pop3_connect(host, port: port, ssl: true) do |yielded_pop3|
+                pop3        = yielded_pop3
+                was_started = pop3.started?
+                raise "test exception"
+              end
+            end.to raise_error("test exception")
+
+            expect(was_started).to be(true)
+            expect(pop3).to_not be_started
+          end
         end
       end
     end

--- a/spec/network/smtp/mixin_spec.rb
+++ b/spec/network/smtp/mixin_spec.rb
@@ -56,6 +56,16 @@ describe Ronin::Support::Network::SMTP::Mixin do
           expect(yielded_smtp).to be_kind_of(Net::SMTP)
         end
 
+        it "must return the block's return value" do
+          pending "need valid SMTP credentials"
+
+          returned_value = subject.smtp_connect(host) do |smtp|
+            :return_value
+          end
+
+          expect(returned_value).to be(:return_value)
+        end
+
         it "must finish the SMTP session after yielding it" do
           pending "need valid SMTP credentials"
 
@@ -69,6 +79,26 @@ describe Ronin::Support::Network::SMTP::Mixin do
 
           expect(was_started).to be(true)
           expect(smtp).to_not be_started
+        end
+
+        context "when the block raises an exception" do
+          it "must finish the SMTP session after yielding it" do
+            pending "need valid SMTP credentials"
+
+            smtp        = nil
+            was_started = nil
+
+            expect do
+              subject.smtp_connect(host) do |yielded_smtp|
+                smtp        = yielded_smtp
+                was_started = smtp.started?
+                raise "test exception"
+              end
+            end.to raise_error("test exception")
+
+            expect(was_started).to be(true)
+            expect(smtp).to_not be_started
+          end
         end
       end
     end

--- a/spec/network/tcp_spec.rb
+++ b/spec/network/tcp_spec.rb
@@ -108,6 +108,30 @@ describe Ronin::Support::Network::TCP do
           expect(socket).to be_closed
         end
 
+        it "must return the block's return value" do
+          returned_value = subject.connect(host,port) do |socket|
+            :return_value
+          end
+
+          expect(returned_value).to eq(:return_value)
+        end
+
+        context "when the block raises an exception" do
+          it "must close the TCPSocket" do
+            socket = nil
+
+            expect do
+              subject.connect(host,port) do |yielded_socket|
+                socket = yielded_socket
+                raise "test exception"
+              end
+            end.to raise_error("test exception")
+
+            expect(socket).to be_kind_of(TCPSocket)
+            expect(socket).to be_closed
+          end
+        end
+
         context "when given the bind_port: keyword argument" do
           let(:bind_port) { 1024 + rand(65535 - 1024) }
 

--- a/spec/network/udp_spec.rb
+++ b/spec/network/udp_spec.rb
@@ -103,6 +103,30 @@ describe Ronin::Support::Network::UDP do
           expect(socket).to be_closed
         end
 
+        it "must return the block's return value" do
+          returned_value = subject.connect(host,port) do |socket|
+            :return_value
+          end
+
+          expect(returned_value).to eq(:return_value)
+        end
+
+        context "when the block raises an exception" do
+          it "must close the UDPSocket" do
+            socket = nil
+
+            expect do
+              subject.connect(host,port) do |yielded_socket|
+                socket = yielded_socket
+                raise "test exception"
+              end
+            end.to raise_error("test exception")
+
+            expect(socket).to be_kind_of(UDPSocket)
+            expect(socket).to be_closed
+          end
+        end
+
         context "when given the bind_port: keyword argument" do
           it "must bind to the local port" do
             bound_port = nil


### PR DESCRIPTION
For the methods `TCP.connect`, `UDP.connect`, `HTTP.connect`, `POP3::Mixin#pop3_connect`, and `SMTP::Mixin#smtp_connect`:

- return the block's return value
- TCP, UDP, POP3, SMTP: close the socket even if the block raises an exception