### PR TITLE
Refactor `ronin/support/encoding/base64` to not use the `Base64` library

### DIFF
--- a/lib/ronin/support/encoding/base64.rb
+++ b/lib/ronin/support/encoding/base64.rb
@@ -16,8 +16,6 @@
 # along with ronin-support.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-require 'base64'
-
 module Ronin
   module Support
     class Encoding < ::Encoding
@@ -48,9 +46,9 @@ module Ronin
         #
         def self.encode(data, mode: nil)
           case mode
-          when :strict   then ::Base64.strict_encode64(data)
-          when :url_safe then ::Base64.urlsafe_encode64(data)
-          when nil       then ::Base64.encode64(data)
+          when :strict   then strict_encode(data)
+          when :url_safe then encode_urlsafe(data)
+          when nil       then [data].pack("m")
           else
             raise(ArgumentError,"Base64 mode must be either :string, :url_safe, or nil: #{mode.inspect}")
           end
@@ -70,12 +68,73 @@ module Ronin
         #
         def self.decode(data, mode: nil)
           case mode
-          when :strict   then ::Base64.strict_decode64(data)
-          when :url_safe then ::Base64.urlsafe_decode64(data)
-          when nil       then ::Base64.decode64(data)
+          when :strict   then strict_decode(data)
+          when :url_safe then decode_urlsafe(data)
+          when nil       then data.unpack1("m")
           else
             raise(ArgumentError,"Base64 mode must be either :string, :url_safe, or nil: #{mode.inspect}")
           end
+        end
+
+        #
+        # Base64 strict encodes the given data.
+        #
+        # @param [String] data
+        #   The data to Base64 encode.
+        #
+        # @return [String]
+        #   The Base64 strict encoded data.
+        #
+        def self.strict_encode(data)
+          [data].pack("m0")
+        end
+
+        #
+        # Base64 strict decodes the given data.
+        #
+        # @param [String] data
+        #   The Base64 data to decode.
+        #
+        # @return [String]
+        #   The strict decoded data.
+        #
+        def self.strict_decode(data)
+          data.unpack1("m0")
+        end
+
+        #
+        # Base64 url-safe encodes the given data.
+        #
+        # @param [String] data
+        #   The data to Base64 encode.
+        #
+        # @return [String]
+        #   The Base64 url-safe encoded data.
+        #
+        def self.encode_urlsafe(data, padding: true)
+          str = strict_encode(data)
+          str.chomp!("==") or str.chomp!("=") unless padding
+          str.tr!("+/", "-_")
+          str
+        end
+
+        #
+        # Base64 url-safe decodes the given data.
+        #
+        # @param [String] data
+        #   The Base64 data to decode.
+        #
+        # @return [String]
+        #   The url-safe decoded data.
+        #
+        def self.decode_urlsafe(data)
+          if !data.end_with?("=") && data.length % 4 != 0
+            data = data.ljust((str.length + 3) & ~3, "=")
+            data.tr!("-_", "+/")
+          else
+            data = data.tr("-_", "+/")
+          end
+          strict_decode(data)
         end
       end
     end

--- a/spec/encoding/base64/core_ext/string_spec.rb
+++ b/spec/encoding/base64/core_ext/string_spec.rb
@@ -13,7 +13,7 @@ describe String do
     subject { "hello" }
 
     it "must Base64 encode the String" do
-      expect(subject.base64_encode).to eq(Base64.encode64(subject))
+      expect(subject.base64_encode).to eq(Ronin::Support::Encoding::Base64.encode(subject))
     end
 
     context "when given the mode: keyword of :strict" do
@@ -21,7 +21,7 @@ describe String do
 
       it "must strict encode the String" do
         expect(subject.base64_encode(mode: :strict)).to eq(
-          Base64.strict_encode64(subject)
+          Ronin::Support::Encoding::Base64.strict_encode(subject)
         )
       end
     end
@@ -31,7 +31,7 @@ describe String do
 
       it "must URL-safe encode the String" do
         expect(subject.base64_encode(mode: :url_safe)).to eq(
-          Base64.strict_encode64(subject)
+          Ronin::Support::Encoding::Base64.encode_urlsafe(subject)
         )
       end
     end
@@ -49,7 +49,7 @@ describe String do
 
   describe "#base64_decode" do
     let(:data)    { "hello" }
-    let(:subject) { Base64.encode64(data) }
+    let(:subject) { Ronin::Support::Encoding::Base64.encode(data) }
 
     it "must Base64 decode the given data" do
       expect(subject.base64_decode).to eq(data)
@@ -57,7 +57,7 @@ describe String do
 
     context "when given the mode: keyword of :strict" do
       let(:data)    { 'A' * 256 }
-      let(:subject) { Base64.strict_encode64(data) }
+      let(:subject) { Ronin::Support::Encoding::Base64.strict_encode(data) }
 
       it "must strict decode the given data" do
         expect(subject.base64_decode(mode: :strict)).to eq(data)
@@ -66,7 +66,7 @@ describe String do
 
     context "when given the mode: keyword of :url_safe" do
       let(:data)    { 'A' * 256 }
-      let(:subject) { Base64.urlsafe_encode64(data) }
+      let(:subject) { Ronin::Support::Encoding::Base64.encode_urlsafe(data) }
 
       it "must URL-safe decode the given data" do
         expect(subject.base64_decode(mode: :url_safe)).to eq(data)

--- a/spec/encoding/base64_spec.rb
+++ b/spec/encoding/base64_spec.rb
@@ -4,9 +4,10 @@ require 'ronin/support/encoding/base64'
 describe Ronin::Support::Encoding::Base64 do
   describe ".encode" do
     let(:data) { "hello" }
+    let(:encoded_data) { [data].pack("m") }
 
     it "must Base64 encode the given data" do
-      expect(subject.encode(data)).to eq(Base64.encode64(data))
+      expect(subject.encode(data)).to eq(encoded_data)
     end
 
     context "when given the mode: keyword of :strict" do
@@ -14,7 +15,7 @@ describe Ronin::Support::Encoding::Base64 do
 
       it "must strict encode the given data" do
         expect(subject.encode(data, mode: :strict)).to eq(
-          Base64.strict_encode64(data)
+          described_class.strict_encode(data)
         )
       end
     end
@@ -24,7 +25,7 @@ describe Ronin::Support::Encoding::Base64 do
 
       it "must URL-safe encode the given data" do
         expect(subject.encode(data, mode: :url_safe)).to eq(
-          Base64.strict_encode64(data)
+          described_class.encode_urlsafe(data)
         )
       end
     end
@@ -42,7 +43,7 @@ describe Ronin::Support::Encoding::Base64 do
 
   describe ".decode" do
     let(:data)         { "hello" }
-    let(:encoded_data) { Base64.encode64(data) }
+    let(:encoded_data) { [data].pack("m") }
 
     it "must Base64 decode the given data" do
       expect(subject.decode(encoded_data)).to eq(data)
@@ -50,7 +51,7 @@ describe Ronin::Support::Encoding::Base64 do
 
     context "when given the mode: keyword of :strict" do
       let(:data)         { 'A' * 256 }
-      let(:encoded_data) { Base64.strict_encode64(data) }
+      let(:encoded_data) { described_class.strict_encode(data) }
 
       it "must strict decode the given data" do
         expect(subject.decode(encoded_data, mode: :strict)).to eq(data)
@@ -59,7 +60,7 @@ describe Ronin::Support::Encoding::Base64 do
 
     context "when given the mode: keyword of :url_safe" do
       let(:data)         { 'A' * 256 }
-      let(:encoded_data) { Base64.urlsafe_encode64(data) }
+      let(:encoded_data) { described_class.encode_urlsafe(data) }
 
       it "must URL-safe decode the given data" do
         expect(subject.decode(encoded_data, mode: :url_safe)).to eq(data)
@@ -74,6 +75,42 @@ describe Ronin::Support::Encoding::Base64 do
           subject.decode(encoded_data, mode: mode)
         }.to raise_error(ArgumentError,"Base64 mode must be either :string, :url_safe, or nil: #{mode.inspect}")
       end
+    end
+  end
+
+  describe "#strict_encode" do
+    let(:data) { "AAAA" }
+    let(:encoded_data) { "QUFBQQ==" }
+
+    it "must strict encode the given data" do
+      expect(subject.strict_encode(data)).to eq(encoded_data)
+    end
+  end
+
+  describe "#encode_urlsafe" do
+    let(:data) { "AAAA" }
+    let(:encoded_data) { "QUFBQQ==" }
+
+    it "must URL-safe encode the given data" do
+      expect(subject.encode_urlsafe(data)).to eq(encoded_data)
+    end
+  end
+
+  describe "#strict_decod" do
+    let(:data) { "QUFBQQ==" }
+    let(:decoded_data) { "AAAA" }
+
+    it "must strict decode the given data" do
+      expect(subject.strict_decode(data)).to eq(decoded_data)
+    end
+  end
+
+  describe "decode_urlsafe" do
+    let(:data) { "QUFBQQ==" }
+    let(:decoded_data) { "AAAA" }
+
+    it "must URL-safe decode the given data" do
+      expect(subject.decode_urlsafe(data)).to eq(decoded_data)
     end
   end
 end


### PR DESCRIPTION
#563 #561